### PR TITLE
Allow use of alternative indexes.

### DIFF
--- a/lib/rummageable.rb
+++ b/lib/rummageable.rb
@@ -20,9 +20,9 @@ module Rummageable
     @rummager_host || Plek.current.find(rummager_service_name)
   end
 
-  attr_writer :path_prefix
-  def path_prefix
-    @path_prefix || ""
+  attr_writer :default_index
+  def default_index
+    @default_index || ""
   end
 
   attr_writer :implementation
@@ -33,20 +33,20 @@ module Rummageable
   # documents must be either a hash (for one document) or an array of hashes
   # (for multiple documents)
   #
-  def index(documents)
-    implementation.index(documents)
+  def index(documents, index_name = default_index)
+    implementation.index(documents, index_name)
   end
 
-  def delete(link)
-    implementation.delete(link)
+  def delete(link, index_name = default_index)
+    implementation.delete(link, index_name)
   end
 
-  def amend(link, amendments)
-    implementation.amend(link, amendments)
+  def amend(link, amendments, index_name = default_index)
+    implementation.amend(link, amendments, index_name)
   end
 
-  def commit
-    implementation.commit
+  def commit(index_name = default_index)
+    implementation.commit(index_name)
   end
 
   VALID_KEYS = [

--- a/lib/rummageable/fake.rb
+++ b/lib/rummageable/fake.rb
@@ -1,12 +1,12 @@
 module Rummageable
   class Fake
-    def index(documents)
+    def index(documents, index_name)
     end
 
-    def delete(link)
+    def delete(link, index_name)
     end
 
-    def commit
+    def commit(index_name)
     end
 
     def validate_structure(hash, parents=[])

--- a/lib/rummageable/implementation.rb
+++ b/lib/rummageable/implementation.rb
@@ -1,28 +1,28 @@
 module Rummageable
   class Implementation
-    def index(documents)
+    def index(documents, index_name)
       documents = [documents].flatten
       documents.each do |document|
         validate_structure document
       end
-      url = Rummageable.rummager_host + Rummageable.path_prefix + "/documents"
+      url = Rummageable.rummager_host + index_name + "/documents"
       0.step(documents.length - 1, CHUNK_SIZE).each do |i|
         body = JSON.dump(documents[i, CHUNK_SIZE])
         RestClient.post url, body, content_type: :json, accept: :json
       end
     end
 
-    def amend(link, amendments)
+    def amend(link, amendments, index_name)
       validate_structure amendments
-      RestClient.post url_for(link), amendments
+      RestClient.post url_for(link, index_name), amendments
     end
 
-    def delete(link)
-      RestClient.delete url_for(link), content_type: :json, accept: :json
+    def delete(link, index_name)
+      RestClient.delete url_for(link, index_name), content_type: :json, accept: :json
     end
 
-    def commit
-      url = Rummageable.rummager_host + Rummageable.path_prefix + "/commit"
+    def commit(index_name)
+      url = Rummageable.rummager_host + index_name + "/commit"
       RestClient.post url, {}
     end
 
@@ -43,9 +43,9 @@ module Rummageable
     end
 
   private
-    def url_for(link)
+    def url_for(link, index_name)
       [
-        Rummageable.rummager_host, Rummageable.path_prefix,
+        Rummageable.rummager_host, index_name,
         "/documents/", CGI.escape(link)
       ].join("")
     end

--- a/test/rummageable_test.rb
+++ b/test/rummageable_test.rb
@@ -80,6 +80,30 @@ class RummageableTest < MiniTest::Unit::TestCase
     end
   end
 
+  def test_allows_indexing_to_an_alternative_index
+    document = {
+      "title" => "TITLE",
+      "description" => "DESCRIPTION",
+      "format" => "NAME OF FORMAT",
+      "section" => "NAME OF SECTION",
+      "subsection" => "NAME OF SUBSECTION",
+      "link" => "/link",
+      "indexable_content" => "TEXT",
+      "boost_phrases" => "BOOST",
+      "additional_links" => [
+        {"title" => "LINK1", "link" => "/link1"},
+        {"title" => "LINK2", "link" => "/link2"},
+      ]
+    }
+    json = JSON.dump([document])
+
+    stub_request(:post, "#{API}/alternative/documents").
+      with(body: json).
+      to_return(status: 200, body: '{"status":"OK"}')
+
+    Rummageable.index(document, "/alternative")
+  end
+
   def test_should_post_to_rummageable_host_determined_by_rummager_service_name
     document = {"title" => "TITLE"}
     stub_request(:post, "#{API}/documents")
@@ -98,6 +122,15 @@ class RummageableTest < MiniTest::Unit::TestCase
       to_return(status: 200, body: '{"status":"OK"}')
 
     Rummageable.delete(link)
+  end
+
+  def test_should_allow_deletion_from_an_alternative_index
+    link = "http://example.com/foo"
+
+    stub_request(:delete, "#{API}/alternative/documents/http:%2F%2Fexample.com%2Ffoo").
+      to_return(status: 200, body: '{"status":"OK"}')
+
+    Rummageable.delete(link, '/alternative')
   end
 
   def test_should_post_amendments
@@ -157,6 +190,13 @@ class RummageableTest < MiniTest::Unit::TestCase
       to_return(status: 200, body: '{"result":"OK"}')
 
     Rummageable.commit
+  end
+
+  def test_should_allow_committing_an_alternative_index
+    stub_request(:post, "#{API}/alternative/commit").
+      to_return(status: 200, body: '{"result":"OK"}')
+
+    Rummageable.commit '/alternative'
   end
 
   private


### PR DESCRIPTION
Whitehall needs to be able to index things against two different
indexes, one for specialist content and one for government content.
This change should pass all requests to the default index as before, but allow any request to override the default by passing in
a different index name parameter.

With this in place we will not need the path prefix (not that I
think we were using it anyway), so it has been removed too.

N.B. The pull request to rummager to allow hosting of multiple
different backends is here: https://github.com/alphagov/rummager/pull/26
