### PR TITLE
Allow the use of a "subsubsection" key.

### DIFF
--- a/lib/rummageable.rb
+++ b/lib/rummageable.rb
@@ -55,6 +55,7 @@ module Rummageable
     %w[format],
     %w[section],
     %w[subsection],
+    %w[subsubsection],
     %w[link],
     %w[indexable_content],
     %w[boost_phrases],

--- a/test/rummageable_test.rb
+++ b/test/rummageable_test.rb
@@ -13,6 +13,7 @@ class RummageableTest < MiniTest::Unit::TestCase
       "format" => "NAME OF FORMAT",
       "section" => "NAME OF SECTION",
       "subsection" => "NAME OF SUBSECTION",
+      "subsubsection" => "NAME OF SUBSUBSECTION",
       "link" => "/link",
       "indexable_content" => "TEXT",
       "boost_phrases" => "BOOST",


### PR DESCRIPTION
This is needed for detailed guidance in order to e.g. show
individual breadcrumbs alongside search results.

While it would have been nicer and more "scalable" to combine the
"section", "subsection" & "subsubsection" keys into a single key
with e.g. an array of values, this would require significant changes in
many places. The solution in this commit seems like the most consistent
and least worst option for the moment.

See https://www.pivotaltracker.com/story/show/36615073.
