### PR TITLE
Allow client to delete all documents from an index.

### DIFF
--- a/lib/rummageable.rb
+++ b/lib/rummageable.rb
@@ -41,6 +41,10 @@ module Rummageable
     implementation.delete(link, index_name)
   end
 
+  def delete_all(index_name = default_index)
+    implementation.delete_all(index_name)
+  end
+
   def amend(link, amendments, index_name = default_index)
     implementation.amend(link, amendments, index_name)
   end

--- a/lib/rummageable/implementation.rb
+++ b/lib/rummageable/implementation.rb
@@ -21,6 +21,10 @@ module Rummageable
       RestClient.delete url_for(link, index_name), content_type: :json, accept: :json
     end
 
+    def delete_all(index_name)
+      RestClient.delete unescaped_url_for("*", index_name), content_type: :json, accept: :json
+    end
+
     def commit(index_name)
       url = Rummageable.rummager_host + index_name + "/commit"
       RestClient.post url, {}
@@ -43,11 +47,17 @@ module Rummageable
     end
 
   private
+
+    def url_components(index_name)
+      [Rummageable.rummager_host, index_name, "/documents/"]
+    end
+
     def url_for(link, index_name)
-      [
-        Rummageable.rummager_host, index_name,
-        "/documents/", CGI.escape(link)
-      ].join("")
+      (url_components(index_name) << CGI.escape(link)).join
+    end
+
+    def unescaped_url_for(link, index_name)
+      (url_components(index_name) << link).join
     end
   end
 end

--- a/test/rummageable_test.rb
+++ b/test/rummageable_test.rb
@@ -134,6 +134,20 @@ class RummageableTest < MiniTest::Unit::TestCase
     Rummageable.delete(link, '/alternative')
   end
 
+  def test_should_allow_delete_all
+    stub_request(:delete, "#{API}/documents/*").
+      to_return(status: 200, body: '{"status":"OK"}')
+
+    Rummageable.delete_all
+  end
+
+  def test_should_allow_delete_all_from_an_alternative_index
+    stub_request(:delete, "#{API}/alternative/documents/*").
+      to_return(status: 200, body: '{"status":"OK"}')
+
+    Rummageable.delete_all('/alternative')
+  end
+
   def test_should_post_amendments
     stub_request(:post, "#{API}/documents/%2Ffoobang").
       with(body: {"title" => "Cheese", "indexable_content" => "Blah"}).


### PR DESCRIPTION
We want to be able to delete all documents from an index so we can
completely rebuild an index if it somehow gets in a mess.

This functionality is already exposed by Rummager itself, but there is
currently no access to it via Rummageable.
