### PR TITLE
Iterate when indexing

### DIFF
--- a/lib/rummageable/implementation.rb
+++ b/lib/rummageable/implementation.rb
@@ -1,13 +1,13 @@
 module Rummageable
   class Implementation
     def index(documents, index_name)
-      documents = [documents].flatten
+      documents = documents.is_a?(Hash) ? [documents] : documents
       documents.each do |document|
         validate_structure document
       end
       url = Rummageable.rummager_host + index_name + "/documents"
-      0.step(documents.length - 1, CHUNK_SIZE).each do |i|
-        body = JSON.dump(documents[i, CHUNK_SIZE])
+      documents.each_slice(CHUNK_SIZE).each do |slice|
+        body = JSON.dump(slice)
         RestClient.post url, body, content_type: :json, accept: :json
       end
     end

--- a/lib/rummageable/implementation.rb
+++ b/lib/rummageable/implementation.rb
@@ -2,11 +2,11 @@ module Rummageable
   class Implementation
     def index(documents, index_name)
       documents = documents.is_a?(Hash) ? [documents] : documents
-      documents.each do |document|
-        validate_structure document
-      end
       url = Rummageable.rummager_host + index_name + "/documents"
       documents.each_slice(CHUNK_SIZE).each do |slice|
+        slice.each do |document|
+          validate_structure document
+        end
         body = JSON.dump(slice)
         RestClient.post url, body, content_type: :json, accept: :json
       end

--- a/test/rummageable_test.rb
+++ b/test/rummageable_test.rb
@@ -108,12 +108,12 @@ class RummageableTest < MiniTest::Unit::TestCase
   def test_should_post_to_rummageable_host_determined_by_rummager_service_name
     document = {"title" => "TITLE"}
     stub_request(:post, "#{API}/documents")
-    stub_request(:post, "http://whitehall-search.test.gov.uk/documents")
+    stub_request(:post, "#{Plek.current.find("whitehall-search")}/documents")
     with_rummager_service_name("whitehall-search") do
       Rummageable.index(document)
     end
     assert_not_requested(:post, "#{API}/documents")
-    assert_requested(:post, "http://whitehall-search.test.gov.uk/documents")
+    assert_requested(:post, "#{Plek.current.find("whitehall-search")}/documents")
   end
 
   def test_should_delete_a_document_by_its_link
@@ -181,12 +181,12 @@ class RummageableTest < MiniTest::Unit::TestCase
   def test_should_delete_to_rummageable_host_determined_by_rummager_service_name
     link = "http://example.com/foo"
     stub_request(:delete, "#{API}/documents/http:%2F%2Fexample.com%2Ffoo")
-    stub_request(:delete, "http://whitehall-search.test.gov.uk/documents/http:%2F%2Fexample.com%2Ffoo")
+    stub_request(:delete, "#{Plek.current.find("whitehall-search")}/documents/http:%2F%2Fexample.com%2Ffoo")
     with_rummager_service_name("whitehall-search") do
       Rummageable.delete(link)
     end
     assert_not_requested(:delete, "#{API}/#{API}/documents/http:%2F%2Fexample.com%2Ffoo")
-    assert_requested(:delete, "http://whitehall-search.test.gov.uk/documents/http:%2F%2Fexample.com%2Ffoo")
+    assert_requested(:delete, "#{Plek.current.find("whitehall-search")}/documents/http:%2F%2Fexample.com%2Ffoo")
   end
 
   def test_should_defer_to_plek_for_the_location_of_the_rummager_host


### PR DESCRIPTION
This should speed up performance when indexing a lot of documents at once (rake rummager:index) by avoiding loading them all into memory simultaneously. 

It still iterates over them all calling validate. I wasn't sure of the motivation for doing this before starting indexing vs validating each document batch in turn at index time. Thoughts welcome.
