### PR TITLE
Switch to multijson and use yajl

### DIFF
--- a/lib/rummageable.rb
+++ b/lib/rummageable.rb
@@ -1,5 +1,4 @@
 require "rest_client"
-require 'yajl'
 require 'multi_json'
 require "plek"
 

--- a/lib/rummageable.rb
+++ b/lib/rummageable.rb
@@ -1,5 +1,6 @@
 require "rest_client"
-require "json"
+require 'yajl'
+require 'multi_json'
 require "plek"
 
 require "rummageable/implementation"

--- a/lib/rummageable/implementation.rb
+++ b/lib/rummageable/implementation.rb
@@ -7,7 +7,7 @@ module Rummageable
         slice.each do |document|
           validate_structure document
         end
-        body = JSON.dump(slice)
+        body = MultiJson.encode(slice)
         RestClient.post url, body, content_type: :json, accept: :json
       end
     end

--- a/rummageable.gemspec
+++ b/rummageable.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.summary = "Mediator for apps that want their content to be in the search index"
   s.test_files = Dir["test/**/*_test.rb"]
-  s.add_dependency "json"
+  s.add_dependency "yajl-ruby"
+  s.add_dependency "multi_json"
   s.add_dependency "rest-client"
   s.add_dependency "plek", '>= 0.5.0'
   s.add_development_dependency "rake"

--- a/rummageable.gemspec
+++ b/rummageable.gemspec
@@ -13,11 +13,11 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.summary = "Mediator for apps that want their content to be in the search index"
   s.test_files = Dir["test/**/*_test.rb"]
-  s.add_dependency "yajl-ruby"
   s.add_dependency "multi_json"
   s.add_dependency "rest-client"
   s.add_dependency "plek", '>= 0.5.0'
   s.add_development_dependency "rake"
   s.add_development_dependency "webmock"
   s.add_development_dependency "gem_publisher", "1.0.0"
+  s.add_development_dependency "yajl-ruby", "1.1.0"
 end

--- a/test/rummageable_test.rb
+++ b/test/rummageable_test.rb
@@ -22,7 +22,7 @@ class RummageableTest < MiniTest::Unit::TestCase
         {"title" => "LINK2", "link" => "/link2"},
       ]
     }
-    json = JSON.dump([document])
+    json = MultiJson.encode([document])
 
     stub_request(:post, "#{API}/documents").
       with(body: json).
@@ -36,7 +36,7 @@ class RummageableTest < MiniTest::Unit::TestCase
       {"title" => "DOC1"},
       {"title" => "DOC2"}
     ]
-    json = JSON.dump(documents)
+    json = MultiJson.encode(documents)
 
     stub_request(:post, "#{API}/documents").
       with(body: json).
@@ -52,8 +52,8 @@ class RummageableTest < MiniTest::Unit::TestCase
       to_return(status: 200, body: '{"status":"OK"}')
 
     Rummageable.index(documents)
-    assert_requested :post, "#{API}/documents", body: JSON.dump(documents[0, 20])
-    assert_requested :post, "#{API}/documents", body: JSON.dump(documents[20, 1])
+    assert_requested :post, "#{API}/documents", body: MultiJson.encode(documents[0, 20])
+    assert_requested :post, "#{API}/documents", body: MultiJson.encode(documents[20, 1])
   end
 
   def test_should_raise_an_exception_if_a_document_has_symbol_keys
@@ -96,7 +96,7 @@ class RummageableTest < MiniTest::Unit::TestCase
         {"title" => "LINK2", "link" => "/link2"},
       ]
     }
-    json = JSON.dump([document])
+    json = MultiJson.encode([document])
 
     stub_request(:post, "#{API}/alternative/documents").
       with(body: json).


### PR DESCRIPTION
yajl gives us better error messages when encoding issue occur and is faster than the pure JSON lib.

Also it would be good to standardise as yajl is the default json parser in rails
