### PR TITLE
Remove dead 'additional links' code

### DIFF
--- a/lib/rummageable.rb
+++ b/lib/rummageable.rb
@@ -63,9 +63,7 @@ module Rummageable
     %w[link],
     %w[indexable_content],
     %w[boost_phrases],
-    %w[additional_links title],
-    %w[additional_links link],
-    %w[additional_links link_order],
+    %w[link_order],
   ]
 
   def validate_structure(hash, parents=[])

--- a/test/rummageable_test.rb
+++ b/test/rummageable_test.rb
@@ -16,11 +16,7 @@ class RummageableTest < MiniTest::Unit::TestCase
       "subsubsection" => "NAME OF SUBSUBSECTION",
       "link" => "/link",
       "indexable_content" => "TEXT",
-      "boost_phrases" => "BOOST",
-      "additional_links" => [
-        {"title" => "LINK1", "link" => "/link1"},
-        {"title" => "LINK2", "link" => "/link2"},
-      ]
+      "boost_phrases" => "BOOST"
     }
     json = MultiJson.encode([document])
 
@@ -70,17 +66,6 @@ class RummageableTest < MiniTest::Unit::TestCase
     end
   end
 
-  def test_should_raise_an_exception_if_a_document_has_unrecognised_nested_keys
-    document = {
-      "additional_links" => [
-        {"foo" => "bar"}
-      ]
-    }
-    assert_raises Rummageable::InvalidDocument do
-      Rummageable.index(document)
-    end
-  end
-
   def test_allows_indexing_to_an_alternative_index
     document = {
       "title" => "TITLE",
@@ -90,11 +75,7 @@ class RummageableTest < MiniTest::Unit::TestCase
       "subsection" => "NAME OF SUBSECTION",
       "link" => "/link",
       "indexable_content" => "TEXT",
-      "boost_phrases" => "BOOST",
-      "additional_links" => [
-        {"title" => "LINK1", "link" => "/link1"},
-        {"title" => "LINK2", "link" => "/link2"},
-      ]
+      "boost_phrases" => "BOOST"
     }
     json = MultiJson.encode([document])
 


### PR DESCRIPTION
The additional_links field was originally used in parted content (guides,
benefits) to display links to the individual parts. We're not displaying
these links any more in the search results, nor are we submitting them to
Rummager.

Related: https://github.com/alphagov/rummager/pull/75
