### PR TITLE
Use https for rubygems.org in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source "https://rubygems.org"
 gemspec


### PR DESCRIPTION
This was generating a warning that we were using unsecured HTTP.
