### PR TITLE
Don't try and parse JSON when the response is empty

### DIFF
--- a/lib/rummageable.rb
+++ b/lib/rummageable.rb
@@ -74,7 +74,7 @@ module Rummageable
 
     def log_response(method, url, call_time, response)
       time = sprintf('%.03f', call_time)
-      result = JSON.parse(response).fetch('result', 'UNKNOWN')
+      result = response.length > 0 ? JSON.parse(response).fetch('result', 'UNKNOWN') : "UNKNOWN"
       @logger.info("Rummageable response: #{method.upcase} #{url} - time: #{time}s, result: #{result}")
     end
 

--- a/test/add_test.rb
+++ b/test/add_test.rb
@@ -104,4 +104,15 @@ class AddTest < MiniTest::Unit::TestCase
     index = Rummageable::Index.new(rummager_url, index_name, logger: logger)
     index.add(one_document)
   end
+
+  def test_should_return_unknown_status_for_blank_response
+    RestClient.expects(:send).returns("")
+    Rummageable::Index.any_instance.stubs(:sleep)
+
+    logger = stub('logger', debug: true, info: true)
+    logger.expects(:info).once.with(regexp_matches(/result: UNKNOWN/))
+
+    index = Rummageable::Index.new(rummager_url, index_name, logger: logger)
+    index.add(one_document)
+  end
 end


### PR DESCRIPTION
When the response from a request is empty (eg. when requests are stubbed out in a test), attempting to parse the response as JSON raises an exception.

This changes the log_response method to return an 'UNKNOWN' status if the response is empty, consistent with behaviour when the response is JSON but doesn't contain a result key.
