### PR TITLE
Allow deletion of nonedition documents

### DIFF
--- a/lib/rummageable.rb
+++ b/lib/rummageable.rb
@@ -36,9 +36,9 @@ module Rummageable
       end
     end
 
-    def delete(link)
+    def delete(id, type = 'edition')
       repeatedly do
-        make_request(:delete, documents_url(link: link))
+        make_request(:delete, documents_url(id: id, type: type))
       end
     end
 
@@ -89,8 +89,11 @@ module Rummageable
     end
 
     def documents_url(options = {})
+      options[:id] ||= options[:link]
+
       parts = [@index_url, 'documents']
-      parts << CGI.escape(options[:link]) if options[:link]
+      parts << CGI.escape(options[:type]) if options[:type]
+      parts << CGI.escape(options[:id]) if options[:id]
       parts.join('/')
     end
   end

--- a/rummageable.gemspec
+++ b/rummageable.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "webmock"
   s.add_development_dependency "yajl-ruby", "1.1.0"
+  s.add_development_dependency "debugger"
 end

--- a/test/delete_test.rb
+++ b/test/delete_test.rb
@@ -6,11 +6,11 @@ class DeleteTest < MiniTest::Unit::TestCase
   end
 
   def stub_successful_delete_request
-    stub_request(:delete, link_url).to_return(status(200))
+    stub_request(:delete, documents_url(id: link, type: 'edition')).to_return(status(200))
   end
 
   def stub_one_failed_delete_request
-    stub_request(:delete, link_url).
+    stub_request(:delete, documents_url(id: link, type: 'edition')).
       to_return(status(502)).times(1).then.to_return(status(200))
   end
 
@@ -18,7 +18,19 @@ class DeleteTest < MiniTest::Unit::TestCase
     stub_successful_delete_request
     index = Rummageable::Index.new(rummager_url, index_name)
     index.delete(link)
-    assert_requested :delete, link_url do |request|
+    assert_requested :delete, documents_url(id: link, type: 'edition') do |request|
+      request.headers['Content-Type'] == 'application/json' &&
+        request.headers['Accept'] == 'application/json'
+    end
+  end
+
+  def test_should_delete_a_document_by_its_type_and_id
+    stub_request(:delete, documents_url(id: 'jobs-exact', type: 'best_bet')).to_return(status(200))
+
+    index = Rummageable::Index.new(rummager_url, index_name)
+    index.delete('jobs-exact', 'best_bet')
+
+    assert_requested :delete, documents_url(id: 'jobs-exact', type: 'best_bet') do |request|
       request.headers['Content-Type'] == 'application/json' &&
         request.headers['Accept'] == 'application/json'
     end
@@ -39,7 +51,7 @@ class DeleteTest < MiniTest::Unit::TestCase
     Rummageable::Index.any_instance.expects(:sleep).once
     index = Rummageable::Index.new(rummager_url, index_name)
     index.delete(link)
-    assert_requested :delete, link_url, times: 2
+    assert_requested :delete, documents_url(id: link, type: 'edition'), times: 2
   end
 
   def test_delete_should_log_attempts_to_delete_documents_from_rummager

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ require 'minitest/autorun'
 require 'mocha/setup'
 require 'webmock/minitest'
 require 'rummageable'
+require 'debugger'
 
 ENV['RACK_ENV'] = 'test'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,8 +20,11 @@ class MiniTest::Unit::TestCase
   end
 
   def documents_url(options = {})
+    options[:id] ||= options[:link]
+
     parts = rummager_url, options.fetch(:index, index_name), 'documents'
-    parts << CGI.escape(options[:link]) if options[:link]
+    parts << CGI.escape(options[:type]) if options[:type]
+    parts << CGI.escape(options[:id]) if options[:id]
     parts.join('/')
   end
 


### PR DESCRIPTION
Do not merge before https://github.com/alphagov/rummager/pull/234

Requires an update to the Rummager endpoint.

Delete by ElasticSearch type and id instead of "link". …
Backwards compatible:
- Defaults id to link
- Defaults type to 'edition'
