### PR TITLE
Change delete to take an options hash

### DIFF
--- a/lib/rummageable.rb
+++ b/lib/rummageable.rb
@@ -36,7 +36,8 @@ module Rummageable
       end
     end
 
-    def delete(id, type = 'edition')
+    def delete(id, options = {})
+      type = options[:type] || 'edition'
       repeatedly do
         make_request(:delete, documents_url(id: id, type: type))
       end

--- a/test/delete_test.rb
+++ b/test/delete_test.rb
@@ -28,7 +28,7 @@ class DeleteTest < MiniTest::Unit::TestCase
     stub_request(:delete, documents_url(id: 'jobs-exact', type: 'best_bet')).to_return(status(200))
 
     index = Rummageable::Index.new(rummager_url, index_name)
-    index.delete('jobs-exact', 'best_bet')
+    index.delete('jobs-exact', type: 'best_bet')
 
     assert_requested :delete, documents_url(id: 'jobs-exact', type: 'best_bet') do |request|
       request.headers['Content-Type'] == 'application/json' &&


### PR DESCRIPTION
We've belatedly realised that it would be much nicer for the new delete
endpoint to take an options parameter instead of a second string
parameter.  (There may be more options in future, and this approach
means it's clear in the calling code what the new parameter is for.)

This is a breaking change from the syntax used in 1.1.0, but no apps are
yet using that syntax.  It is not a breaking change from the syntax used
in the previous 1.0.1 version.
