### PR TITLE
Clarify that this gem is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Rummageable
+# Rummageable (DEPRECATED)
+
+**This gem is deprecated. Please use [gds-api-adapters](http://www.rubydoc.info/github/alphagov/gds-api-adapters/master/GdsApi/Rummager).**
 
 Rummageable is a ruby gem to simplify communication with Rummager to
 create/update/remove items in the gov.uk search index.


### PR DESCRIPTION
We are no longer using this gem to send things to Rummager. It is still being used by some apps, so we can't send it to the gds-attic yet, but new apps should not use it.
