### PR TITLE
Deprecate rummageable

### DIFF
--- a/lib/rummageable/version.rb
+++ b/lib/rummageable/version.rb
@@ -1,3 +1,3 @@
 module Rummageable
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end

--- a/rummageable.gemspec
+++ b/rummageable.gemspec
@@ -6,13 +6,13 @@ require 'rummageable/version'
 Gem::Specification.new do |s|
   s.name = "rummageable"
   s.version = Rummageable::VERSION
-  s.authors = ["GovUK Beta Team"]
-  s.description = "Mediator for apps that want their content to be in the search index"
+  s.authors = ["Government Digital Service"]
+  s.description = "DEPRECATED - Mediator for apps that want their content to be in the search index"
   s.files = Dir["lib/**/*.rb"]
   s.homepage = "https://github.com/alphagov/rummageable"
   s.license = 'MIT'
   s.require_paths = ["lib"]
-  s.summary = "Mediator for apps that want their content to be in the search index"
+  s.summary = "DEPRECATED - Mediator for apps that want their content to be in the search index"
   s.test_files = Dir["test/**/*_test.rb"]
   s.add_dependency "multi_json"
   s.add_dependency "null_logger"


### PR DESCRIPTION
This commit marks this gem as deprecated and releases a new version to update the description on rubygems.org.